### PR TITLE
feat: Set keyboard appearance to dark globally

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
+import { TextInput } from 'react-native';
 import { ConvexProvider, ConvexReactClient } from "convex/react";
 import SplashScreen from './onboarding/splash';
 import SwipeableOnboarding from './onboarding/SwipeableOnboarding';
@@ -29,6 +30,15 @@ export default function App() {
   const [currentScreen, setCurrentScreen] = useState('splash');
   const [userPhoneNumber, setUserPhoneNumber] = useState('');
   const [userPin, setUserPin] = useState('');
+
+  // Set global default props for TextInput to use dark keyboard
+  useEffect(() => {
+    const TextInputAny = TextInput as any;
+    if (TextInputAny.defaultProps == null) {
+      TextInputAny.defaultProps = {};
+    }
+    TextInputAny.defaultProps.keyboardAppearance = 'dark';
+  }, []);
 
 
   const handleSplashFinish = () => {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "dark",
     "newArchEnabled": true,
     "splash": {
       "image": "./assets/splash-icon.png",


### PR DESCRIPTION
- Added global TextInput configuration to use dark keyboard appearance by default
- Changed app userInterfaceStyle from "light" to "dark" for consistent dark theme
- Eliminates need for individual keyboardAppearance props on each TextInput

🤖 Generated with [Claude Code](https://claude.ai/code)