### PR TITLE
Fix card dismissal bounce animation issue

### DIFF
--- a/apps/mobile/screens/HomeScreen.tsx
+++ b/apps/mobile/screens/HomeScreen.tsx
@@ -69,7 +69,6 @@ export default function HomeScreen({ onAddWallet, onSignOut }: HomeScreenProps =
             duration: 200,
             useNativeDriver: true,
           }).start(() => {
-            translateY.setValue(0);
             handlePaymentComplete();
           });
         } else {
@@ -97,6 +96,7 @@ export default function HomeScreen({ onAddWallet, onSignOut }: HomeScreenProps =
   };
 
   const handleCardPress = (card: Card) => {
+    translateY.setValue(0); // Reset position before showing modal
     setSelectedCard(card);
     setShowPaymentReady(true);
   };


### PR DESCRIPTION
- Reset translateY when opening modal instead of after closing
- Remove bounce effect that occurred after swipe-down dismissal
- Ensures smooth single swipe-down animation without ricochet

🤖 Generated with [Claude Code](https://claude.ai/code)