### PR TITLE
Make email field view-only in settings

### DIFF
--- a/apps/mobile/screens/SettingsScreen.tsx
+++ b/apps/mobile/screens/SettingsScreen.tsx
@@ -119,17 +119,15 @@ export default function SettingsScreen({ onBack, onSignOut, onAddWallet, current
           )}
           {renderSeparator()}
           {renderSettingRow(
-            "Email", 
-            "alex@example.com", 
-            undefined, 
-            () => console.log("Email")
-          )}
-          {renderSeparator()}
-          {renderSettingRow(
             "Phone", 
             "+1 (555) 123-4567", 
             undefined, 
             () => console.log("Phone")
+          )}
+          {renderSeparator()}
+          {renderSettingRow(
+            "Email", 
+            "alex@example.com"
           )}
         </View>
 


### PR DESCRIPTION
- Remove clickable arrow from email field
- Reorder fields to group clickable items together
- Email field is now at the bottom of the Transaction Defaults section

🤖 Generated with [Claude Code](https://claude.ai/code)