### PR TITLE
Rename "Payment Cards" section to "Payment Wallets" in settings

### DIFF
--- a/apps/mobile/screens/SettingsScreen.tsx
+++ b/apps/mobile/screens/SettingsScreen.tsx
@@ -83,8 +83,8 @@ export default function SettingsScreen({ onBack, onSignOut, onAddWallet, current
       </View>
 
       <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
-        {/* Payment Cards Section */}
-        {renderSectionHeader("PAYMENT CARDS")}
+        {/* Payment Wallets Section */}
+        {renderSectionHeader("PAYMENT WALLETS")}
         <View style={styles.section}>
           {renderSettingRow(
             "Add Wallet", 


### PR DESCRIPTION
Updated the section header text from "PAYMENT CARDS" to "PAYMENT WALLETS" to better reflect the wallet-focused functionality of the app.

🤖 Generated with [Claude Code](https://claude.ai/code)